### PR TITLE
Fix opencv frame issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ brew install opencv tesseract leptonica
 
 ## Compiling
 
-<!-- One of the crates [rustube](https://lib.rs/crates/rustube) in the project requires nightly compiler so the project only compiles on nightly compiler at the moment. -->
+One of the crates [rustube](https://lib.rs/crates/rustube) in the project requires nightly compiler so the project only compiles on nightly compiler at the moment.
 
 Server side uses ```sqlx``` which does compile time query checking so a db must be present on the compilation time. To set the compile time db and run migrations;
 
@@ -162,6 +162,6 @@ It works the same way for the second stream as well.
 ![lastfm_2](images/example_2_lastfm.png)
 ![listenbrainz_2](images/example_2_listenbrainz.png)
 
-# Limitations
+<!-- # Limitations
 
-It's known that opencv occasionally (sometimes consecutively) fails to read header information from streams but I haven't managed to find the direct cause of this problem. Because of it, it's possible that some listen information might not be sent. Even with no guarantees, it's better than nothing!
+It's known that opencv occasionally (sometimes consecutively) fails to read header information from streams but I haven't managed to find the direct cause of this problem. Because of it, it's possible that some listen information might not be sent. Even with no guarantees, it's better than nothing! -->

--- a/lofigirl_sys/Cargo.toml
+++ b/lofigirl_sys/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 [dependencies]
 lofigirl_shared_common = { path = "../lofigirl_shared_common"}
 opencv = { version = "0.64", features = ["clang-runtime"]}
-ytextract = "0.11"
-rustube = {version = "0.3", optional = true}
+ytextract = { version = "0.11", optional = true}
+rustube = "0.3"
 leptess = "0.13"
 anyhow = "1.0"
 thiserror = "1.0"
@@ -18,4 +18,4 @@ url = "2.2"
 tracing = "0.1"
 
 [features]
-no_ytextract = ["rustube"]
+no_ytextract = ["ytextract"]

--- a/lofigirl_sys/src/image.rs
+++ b/lofigirl_sys/src/image.rs
@@ -41,27 +41,23 @@ impl ImageProcessor {
         // CAPTURE
         let raw_link = self.link_capturer.get_raw_link(&self.video_url).await?;
         let mut capturer = VideoCapture::from_file(&raw_link, opencv::videoio::CAP_FFMPEG)?;
+        capturer.set(opencv::videoio::CAP_PROP_FRAME_WIDTH, 1920.0)?;
+        capturer.set(opencv::videoio::CAP_PROP_FRAME_HEIGHT, 1080.0)?;
         let mut full_image = Mat::default();
         let params = Vector::new();
         capturer
-            .read(&mut full_image)?
-            .then(|| ())
-            .ok_or(ImageProcessingError::ImageReadError)?;
+            .read(&mut full_image)?;
         #[cfg(debug_assertions)]
-        opencv::imgcodecs::imwrite("debug_full.jpg", &full_image, &params)?
-            .then(|| ())
-            .ok_or(ImageProcessingError::ImageWriteError)?;
+        opencv::imgcodecs::imwrite("debug_full.jpg", &full_image, &params)?;
         // CROP
         let image_dimensions = full_image.mat_size();
         (image_dimensions.len() == 2)
-            .then(|| ())
-            .ok_or(ImageProcessingError::ImageDimensionsError)?;
-        let roi = Rect_::new(0, 0, image_dimensions[1], image_dimensions[0] / 10);
+           .then(|| ())
+           .ok_or(ImageProcessingError::ImageDimensionsError)?;
+        let roi = Rect_::new(0, 0, 1920, 108);
         let cropped_image = Mat::roi(&full_image, roi)?;
         #[cfg(debug_assertions)]
-        opencv::imgcodecs::imwrite("debug_cropped.jpg", &cropped_image, &params)?
-            .then(|| ())
-            .ok_or(ImageProcessingError::ImageWriteError)?;
+        opencv::imgcodecs::imwrite("debug_cropped.jpg", &cropped_image, &params)?;
         // MASK
         let mut masked_image = Mat::default();
         opencv::core::in_range(
@@ -71,14 +67,10 @@ impl ImageProcessor {
             &mut masked_image,
         )?;
         #[cfg(debug_assertions)]
-        opencv::imgcodecs::imwrite("debug_masked.jpg", &masked_image, &params)?
-            .then(|| ())
-            .ok_or(ImageProcessingError::ImageWriteError)?;
+        opencv::imgcodecs::imwrite("debug_masked.jpg", &masked_image, &params)?;
         // ENCODE
         let mut buf = Vector::new();
-        opencv::imgcodecs::imencode(".jpg", &masked_image, &mut buf, &params)?
-            .then(|| ())
-            .ok_or(ImageProcessingError::ImageEncodeError)?;
+        opencv::imgcodecs::imencode(".jpg", &masked_image, &mut buf, &params)?;
         // OCR
         self.ocr.set_image_from_mem(buf.as_slice())?;
         self.ocr.set_source_resolution(DPI);
@@ -91,14 +83,6 @@ impl ImageProcessor {
 
 #[derive(Error, Debug)]
 pub enum ImageProcessingError {
-    #[error("Reading the frame has failed.")]
-    ImageReadError,
-    #[error("Writing the image for debug has failed.")]
-    ImageWriteError,
-    #[error("Encoding the image has failed.")]
-    ImageEncodeError,
-    #[error("There is a problem with the frame dimensions.")]
+    #[error("Read frame has no dimensions. There is a problem with the reading the stream.")]
     ImageDimensionsError,
-    #[error("Masking the frame has failed.")]
-    ImageMaskError,
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Setting image dimensions before reading might substantially reduce the amount of read issues on opencv. 

Will hopefully fix #138.