### PR TITLE
New dynamic track endpoint 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
+checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.8.0"
+version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
+checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -171,6 +171,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "impl-more",
  "itoa",
  "language-tags",
  "log",
@@ -851,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
 dependencies = [
  "jobserver",
  "libc",
@@ -928,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -938,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2318,6 +2319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2568,7 @@ dependencies = [
  "lofigirl_shared_listen",
  "lofigirl_sys",
  "notify-rust",
+ "percent-encoding",
  "reqwest 0.12.5",
  "serde",
  "serde_json",
@@ -2600,7 +2608,6 @@ name = "lofigirl_shared_common"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "once_cell",
  "serde",
  "strsim 0.11.1",
  "thiserror",
@@ -2970,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -3650,9 +3657,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39346a33ddfe6be00cbc17a34ce996818b97b230b87229f10114693becca1268"
+checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3665,13 +3672,12 @@ dependencies = [
 
 [[package]]
 name = "reqwest-retry"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2a94ba69ceb30c42079a137e2793d6d0f62e581a24c06cd4e9bb32e973c7da"
+checksum = "a83df1aaec00176d0fabb65dea13f832d2a446ca99107afc17c5d2d4981221d0"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
  "futures",
  "getrandom",
  "http 1.1.0",
@@ -4006,18 +4012,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4600,15 +4606,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5429,6 +5435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5621,12 +5636,12 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xdg-home"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca91dcf8f93db085f3a0a29358cd0b9d670915468f4290e8b85d118a34211ab8"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/lofigirl_client/Cargo.toml
+++ b/lofigirl_client/Cargo.toml
@@ -18,10 +18,11 @@ anyhow = "1.0"
 thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-url = { version = "2.5", optional = true}
+url = "2.5"
 notify-rust = { version = "4.11", optional = true }
+percent-encoding = "2.3"
 
 
 [features]
-standalone = ["lofigirl_sys", "url"]
+standalone = ["lofigirl_sys"]
 notify = ["notify-rust"]

--- a/lofigirl_client/src/config.rs
+++ b/lofigirl_client/src/config.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Result;
 use lofigirl_shared_common::config::{
     ConfigError, LastFMApiConfig, LastFMClientConfig, ListenBrainzConfig, ServerConfig,
-    ServerSettingsConfig, VideoConfig,
+    ServerSettingsConfig,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{fs::OpenOptions, io::AsyncWriteExt};
@@ -15,7 +15,6 @@ pub struct Config {
     pub lastfm_api: Option<LastFMApiConfig>,
     pub listenbrainz: Option<ListenBrainzConfig>,
     pub session: Option<TokenConfig>,
-    pub video: Option<VideoConfig>,
     pub server: Option<ServerConfig>,
     #[allow(dead_code)]
     pub server_settings: Option<ServerSettingsConfig>,
@@ -28,12 +27,6 @@ impl Config {
         (config.lastfm.is_some() || config.listenbrainz.is_some())
             .then_some(())
             .ok_or(ConfigError::EmptyListeners)?;
-        #[cfg(feature = "standalone")]
-        config
-            .video
-            .is_some()
-            .then_some(())
-            .ok_or(ConfigError::EmptyVideoConfig)?;
         #[cfg(not(feature = "standalone"))]
         config
             .server

--- a/lofigirl_client/src/main.rs
+++ b/lofigirl_client/src/main.rs
@@ -20,9 +20,9 @@ struct Opt {
     /// Configuration toml file.
     #[clap(short, long, value_parser, default_value = "config.toml")]
     config: PathBuf,
-    /// Use second video link for listen info
+    /// LofiGirl Youtube stream URL.
     #[clap(short, long, value_parser)]
-    second: bool,
+    url: url::Url,
 }
 
 fn main() -> Result<()> {
@@ -36,7 +36,8 @@ async fn body() -> Result<()> {
     tracing_subscriber::fmt::init();
     let opt = Opt::parse();
     let mut config = Config::from_toml(&opt.config).await?;
-    let (mut worker, changed) = Worker::new(&mut config, opt.second).await?;
+    let requested_url = opt.url;
+    let (mut worker, changed) = Worker::new(&mut config, requested_url).await?;
     if changed {
         // modify config file so that we can store token and/or session_key
         config.to_toml(&opt.config).await?;

--- a/lofigirl_server/src/config.rs
+++ b/lofigirl_server/src/config.rs
@@ -7,7 +7,7 @@ use tracing::info;
 
 #[derive(Debug, Deserialize)]
 pub struct ServerConfig {
-    pub video: VideoConfig,
+    pub video: Option<VideoConfig>,
     pub lastfm_api: Option<LastFMApiConfig>,
     pub server_settings: ServerSettingsConfig,
 }

--- a/lofigirl_server/src/main.rs
+++ b/lofigirl_server/src/main.rs
@@ -7,7 +7,7 @@ use crate::config::ServerConfig;
 use clap::Parser;
 use server::LofiServer;
 use std::path::PathBuf;
-use worker::ServerWorker;
+use worker::InitServerWorker;
 
 const APP_NAME: &str = "lofigirl_server";
 
@@ -26,7 +26,7 @@ async fn main() -> std::io::Result<()> {
     let opt = Opt::parse();
     let config = ServerConfig::from_toml(&opt.config)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
-    let mut worker = ServerWorker::new(&config)
+    let mut worker = InitServerWorker::new(&config)
         .await
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
     let state = worker.state.clone();

--- a/lofigirl_shared_common/Cargo.toml
+++ b/lofigirl_shared_common/Cargo.toml
@@ -12,5 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 thiserror = "1.0"
 strsim = "0.11"
-once_cell = "1.19"
 tracing = "0.1"

--- a/lofigirl_shared_common/src/lib.rs
+++ b/lofigirl_shared_common/src/lib.rs
@@ -2,12 +2,12 @@ pub mod api;
 pub mod config;
 pub mod track;
 
-use std::time::Duration;
+use std::{sync::LazyLock, time::Duration};
 
-use once_cell::sync::Lazy;
-
-pub static REGULAR_INTERVAL: Lazy<Duration> = Lazy::new(|| Duration::from_secs(15));
-pub static FAST_TRY_INTERVAL: Lazy<Duration> = Lazy::new(|| Duration::from_secs(5));
+pub static REGULAR_INTERVAL: LazyLock<Duration> = LazyLock::new(|| Duration::from_secs(15));
+pub static FAST_TRY_INTERVAL: LazyLock<Duration> = LazyLock::new(|| Duration::from_secs(5));
+pub static STREAM_LAST_READ_TIMEOUT: LazyLock<Duration> =
+    LazyLock::new(|| Duration::from_secs(300));
 pub const SEND_END_POINT: &str = "/send";
 pub const TRACK_END_POINT: &str = "/track";
 pub const LASTFM_SESSION_END_POINT: &str = "/session";

--- a/lofigirl_shared_common/src/track.rs
+++ b/lofigirl_shared_common/src/track.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use strsim::jaro;
 use thiserror::Error;
-use tracing::info;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Track {
@@ -24,7 +23,7 @@ impl Track {
 impl PartialEq for Track {
     fn eq(&self, other: &Track) -> bool {
         let sim = jaro(&self.artist, &other.artist) * jaro(&self.song, &other.song);
-        info!("Track similarity with previous track: {}", sim);
+        tracing::debug!("Track similarity: {}", sim);
         sim > 0.95
     }
 }

--- a/lofigirl_shared_listen/src/listener.rs
+++ b/lofigirl_shared_listen/src/listener.rs
@@ -16,10 +16,6 @@ pub struct Listener {
 }
 
 impl Listener {
-    pub fn new() -> Listener {
-        Default::default()
-    }
-
     pub fn set_lastfm_listener(
         &mut self,
         lastfm_api: &LastFMApiConfig,
@@ -62,7 +58,10 @@ impl Listener {
         if let Some(l) = &self.listenbrainz_listener {
             action.act_for_listenbrainz(l, track)?;
         }
-        info!("Track \"{}\" has been marked {} for a user", track, action);
+        info!(
+            "Track \"{}\" has been marked {} for a listener",
+            track, action
+        );
         Ok(())
     }
 

--- a/lofigirl_sys/src/image.rs
+++ b/lofigirl_sys/src/image.rs
@@ -23,7 +23,7 @@ static HIGH_BOUNDS: LazyLock<BoxedRef<Mat>> =
 
 pub struct ImageProcessor {
     link_capturer: YoutubeLinkCapturer,
-    video_url: Url,
+    pub video_url: Url,
     ocr: LepTess,
 }
 


### PR DESCRIPTION
- Add new dynamic track endpoint which client supplies the track url
- Server dynamically starts processing tracks depending on client demand.
- No longer requested url streams are stopped getting watched after a certain time.

Related to #243 