### PR TITLE
Deprecate old track endpoints

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -194,7 +194,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: '11'
+        java-version: '21'
     - uses: subosito/flutter-action@v2
       with:
         channel: 'stable'

--- a/README.md
+++ b/README.md
@@ -100,14 +100,6 @@ api_secret = "api_secret"
 [listenbrainz] # client optional - server ignore
 token = "token"
 
-# video links on server soon to be deprecated in favour of dynamic track endpoint
-[video] # standalone client and server use, others ignore 
-links = [
-    "https::///www.youtube.com/something",
-    "https::///www.youtube.com/something", # optional
-    "https::///www.youtube.com/something", # optional
-]
-
 [server] # client only mandatory, others would ignore.
 link = "http://127.0.0.1:8080"
 

--- a/example_config.toml
+++ b/example_config.toml
@@ -9,10 +9,6 @@ password = "password"
 [listenbrainz]
 token = "token"
 
-[video]
-link = "https::///www.youtube.com/something"
-second_link = "https::///www.youtube.com/something"
-
 [server]
 link = "http://127.0.0.1:8888"
 

--- a/lofigirl_client/src/config.rs
+++ b/lofigirl_client/src/config.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use anyhow::Result;
 use lofigirl_shared_common::config::{
     ConfigError, LastFMApiConfig, LastFMClientConfig, ListenBrainzConfig, ServerConfig,
-    ServerSettingsConfig,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{fs::OpenOptions, io::AsyncWriteExt};
@@ -16,8 +15,6 @@ pub struct Config {
     pub listenbrainz: Option<ListenBrainzConfig>,
     pub session: Option<TokenConfig>,
     pub server: Option<ServerConfig>,
-    #[allow(dead_code)]
-    pub server_settings: Option<ServerSettingsConfig>,
 }
 
 impl Config {

--- a/lofigirl_flutter_client/lib/config.dart
+++ b/lofigirl_flutter_client/lib/config.dart
@@ -30,8 +30,6 @@ class TokenRequest {
       };
 }
 
-enum LofiStream { chill, sleep }
-
 class Track {
   final String artist;
   final String song;

--- a/lofigirl_server/README.md
+++ b/lofigirl_server/README.md
@@ -35,13 +35,6 @@ cargo build --release -p lofigirl_server
 ## Example Config
 
 ```toml
-[video] # soon to be deprecated in favour of dynamic track endpoint
-links = [
-    "https::///www.youtube.com/something",
-    "https::///www.youtube.com/something", # optional
-    "https::///www.youtube.com/something", # optional
-]
-
 [server_settings]
 token_db = "token.db"
 port = 8888 

--- a/lofigirl_server/src/config.rs
+++ b/lofigirl_server/src/config.rs
@@ -1,13 +1,12 @@
 use std::path::Path;
 
 use anyhow::Result;
-use lofigirl_shared_common::config::{LastFMApiConfig, ServerSettingsConfig, VideoConfig};
+use lofigirl_shared_common::config::{LastFMApiConfig, ServerSettingsConfig};
 use serde::Deserialize;
 use tracing::info;
 
 #[derive(Debug, Deserialize)]
 pub struct ServerConfig {
-    pub video: Option<VideoConfig>,
     pub lastfm_api: Option<LastFMApiConfig>,
     pub server_settings: ServerSettingsConfig,
 }

--- a/lofigirl_server/src/util.rs
+++ b/lofigirl_server/src/util.rs
@@ -1,0 +1,17 @@
+use url::Url;
+
+pub trait YoutubeIdExtractor {
+    fn get_video_id(&self) -> Option<String>;
+}
+
+impl YoutubeIdExtractor for Url {
+    fn get_video_id(&self) -> Option<String> {
+        self.query_pairs().find_map(|(key, value)| {
+            if key == "v" {
+                Some(value.to_string())
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/lofigirl_server/src/webserver/mod.rs
+++ b/lofigirl_server/src/webserver/mod.rs
@@ -7,23 +7,21 @@ use crate::session::TokenDB;
 use actix_cors::Cors;
 
 use actix_web::{web, App, HttpServer};
-use endpoints::{dynamic_track, get_main, get_second, health, send, session, token, track_socket};
+use endpoints::{dynamic_track, health, send, session, token, track_socket};
 use lofigirl_shared_common::config::LastFMApiConfig;
-use lofigirl_shared_common::{track::Track, CHILL_TRACK_API_END_POINT, SLEEP_TRACK_API_END_POINT};
+use lofigirl_shared_common::track::Track;
 use lofigirl_shared_common::{
     HEALTH_END_POINT, LASTFM_SESSION_END_POINT, SEND_END_POINT, TOKEN_END_POINT, TRACK_END_POINT,
     TRACK_SOCKET_END_POINT,
 };
 use parking_lot::RwLock;
 use tokio::sync::watch::Receiver;
-use url::Url;
 
 pub struct AppState {
     pub lastfm_api: Option<LastFMApiConfig>,
-    pub seq_tracks: RwLock<Vec<Option<Track>>>,
-    pub tracks: RwLock<HashMap<Url, Track>>,
-    pub last_requested: RwLock<HashMap<Url, Instant>>,
-    pub track_channels: RwLock<HashMap<Url, Receiver<Track>>>,
+    pub tracks: RwLock<HashMap<String, Track>>,
+    pub last_requested: RwLock<HashMap<String, Instant>>,
+    pub track_channels: RwLock<HashMap<String, Receiver<Track>>>,
     pub token_db: TokenDB,
 }
 
@@ -31,11 +29,9 @@ impl AppState {
     pub async fn new(
         api: Option<LastFMApiConfig>,
         token_db_file: &str,
-        nb_links: usize,
     ) -> anyhow::Result<AppState> {
         Ok(AppState {
             lastfm_api: api,
-            seq_tracks: RwLock::new(vec![None; nb_links]),
             token_db: TokenDB::new(token_db_file).await?,
             tracks: RwLock::new(HashMap::new()),
             track_channels: RwLock::new(HashMap::new()),
@@ -53,15 +49,6 @@ impl LofiServer {
             App::new()
                 .wrap(cors)
                 .app_data(data.clone())
-                // soon to be deprecated two track endpoints
-                .route(
-                    &format!("{}{}", TRACK_END_POINT, CHILL_TRACK_API_END_POINT),
-                    web::get().to(get_main),
-                )
-                .route(
-                    &format!("{}{}", TRACK_END_POINT, SLEEP_TRACK_API_END_POINT),
-                    web::get().to(get_second),
-                )
                 // dynamic track endpoint
                 .route(
                     &format!("{}/{{url}}", TRACK_END_POINT),

--- a/lofigirl_server/src/worker.rs
+++ b/lofigirl_server/src/worker.rs
@@ -1,6 +1,6 @@
-use crate::{config::ServerConfig, webserver::AppState};
+use crate::{util::YoutubeIdExtractor, webserver::AppState};
 use actix_web::web;
-use anyhow::{bail, Result};
+use anyhow::Context;
 use lofigirl_shared_common::{
     track::Track, FAST_TRY_INTERVAL, REGULAR_INTERVAL, STREAM_LAST_READ_TIMEOUT,
 };
@@ -9,112 +9,13 @@ use tokio::sync::watch::Sender;
 use tracing::{info, warn};
 use url::Url;
 
-pub struct InitServerWorker {
-    pub state: web::Data<AppState>,
-    image_procs_queue: Option<Vec<ImageProcessor>>,
-}
-
-impl InitServerWorker {
-    pub async fn new(config: &ServerConfig) -> Result<InitServerWorker> {
-        let image_procs_queue = config
-            .video
-            .iter()
-            .flat_map(|v| {
-                v.links.iter().map(|link| {
-                    let video_url = Url::parse(link).ok()?;
-                    let image_proc = ImageProcessor::new(video_url).ok()?;
-                    Some(image_proc)
-                })
-            })
-            .collect::<Option<Vec<_>>>();
-
-        let len = if let Some(v) = &image_procs_queue {
-            v.len()
-        } else {
-            0
-        };
-
-        let state = web::Data::new(
-            AppState::new(
-                config.lastfm_api.clone(),
-                &config.server_settings.token_db,
-                len,
-            )
-            .await?,
-        );
-        info!(
-            "SeqServerWorker Worker initialized with {} image processors",
-            len
-        );
-        Ok(InitServerWorker {
-            state,
-            image_procs_queue,
-        })
-    }
-
-    pub async fn work(&mut self) -> Result<()> {
-        let image_procs = self.image_procs_queue.take();
-        match image_procs {
-            Some(image_procs) => {
-                let state = self.state.clone();
-                InitServerWorker::start_workers(state, image_procs).await?;
-            }
-            None => bail!("Init image processors failed to start"),
-        }
-        Ok(())
-    }
-
-    async fn start_workers(
-        state: web::Data<AppState>,
-        image_procs: Vec<ImageProcessor>,
-    ) -> Result<()> {
-        // If no image processors, return
-        if image_procs.is_empty() {
-            info!("No image processors to start");
-            return Ok(());
-        }
-        // Start the image processors
-        let mut handles = vec![];
-        let nb_processors = image_procs.len();
-        let artificial_delay = *REGULAR_INTERVAL / nb_processors as u32;
-        for (idx, mut image_proc) in image_procs.into_iter().enumerate() {
-            let state_clone = state.clone();
-            let handle = actix_rt::spawn(async move {
-                loop {
-                    let next_track = image_proc.next_track().await;
-                    match next_track {
-                        Ok(track) => {
-                            {
-                                let mut lock = state_clone.seq_tracks.write();
-                                lock[idx] = Some(track);
-                            }
-                            tokio::time::sleep(*REGULAR_INTERVAL).await;
-                        }
-                        Err(e) => {
-                            warn!("Problem with: {}", e);
-                            tokio::time::sleep(*FAST_TRY_INTERVAL).await;
-                        }
-                    }
-                }
-            });
-            handles.push(handle);
-            info!("Image processor worker {} started", idx);
-            tokio::time::sleep(artificial_delay).await;
-        }
-        for handle in handles {
-            handle.await?;
-        }
-        Ok(())
-    }
-}
-
 pub struct ServerWorker {
     pub state: web::Data<AppState>,
     video_url: Url,
 }
 
 impl ServerWorker {
-    pub fn new(video_url: Url, state: web::Data<AppState>) -> Result<ServerWorker> {
+    pub fn new(video_url: Url, state: web::Data<AppState>) -> anyhow::Result<ServerWorker> {
         Ok(ServerWorker { state, video_url })
     }
 
@@ -122,10 +23,14 @@ impl ServerWorker {
         let state_clone = self.state.clone();
         let mut image_proc = ImageProcessor::new(self.video_url.clone())?;
         info!("New ServerWorker starting for {}", &image_proc.video_url);
+        let youtube_video_id = self
+            .video_url
+            .get_video_id()
+            .context("invalid youtube url")?;
         actix_rt::spawn(async move {
             loop {
                 // Check last read to check if we should stop
-                match state_clone.last_requested.read().get(&image_proc.video_url) {
+                match state_clone.last_requested.read().get(&youtube_video_id) {
                     Some(instant) => {
                         if instant.elapsed() > *STREAM_LAST_READ_TIMEOUT {
                             info!(
@@ -152,13 +57,12 @@ impl ServerWorker {
                         let old_track = state_clone
                             .tracks
                             .write()
-                            .insert(image_proc.video_url.clone(), track);
+                            .insert(youtube_video_id.clone(), track);
                         if old_track.filter(|old| *old == next_track).is_none()
                             && track_tx.send(next_track.clone()).is_err()
                         {
                             warn!("Channel problem")
                         }
-                        // lock.insert(image_proc.video_url.clone(), track);
                         tokio::time::sleep(*REGULAR_INTERVAL).await;
                     }
                     Err(e) => {

--- a/lofigirl_shared_common/src/config.rs
+++ b/lofigirl_shared_common/src/config.rs
@@ -36,10 +36,6 @@ pub struct LastFMApiConfig {
 pub struct ListenBrainzConfig {
     pub token: String,
 }
-#[derive(Debug, Deserialize, Serialize)]
-pub struct VideoConfig {
-    pub links: Vec<String>,
-}
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ServerConfig {
@@ -56,8 +52,6 @@ pub struct ServerSettingsConfig {
 pub enum ConfigError {
     #[error("Neither LastFM nor Listenbrainz config is given.")]
     EmptyListeners,
-    #[error("Video config not found.")]
-    EmptyVideoConfig,
     #[error("Server config not found.")]
     EmptyServerConfig,
 }

--- a/lofigirl_shared_common/src/lib.rs
+++ b/lofigirl_shared_common/src/lib.rs
@@ -17,5 +17,3 @@ pub const TRACK_SOCKET_END_POINT: &str = "/track_ws";
 pub const LASTFM_SESSION_END_POINT: &str = "/session";
 pub const TOKEN_END_POINT: &str = "/token";
 pub const HEALTH_END_POINT: &str = "/health";
-pub const CHILL_TRACK_API_END_POINT: &str = "/1";
-pub const SLEEP_TRACK_API_END_POINT: &str = "/2";

--- a/lofigirl_web_client/src/lib.rs
+++ b/lofigirl_web_client/src/lib.rs
@@ -1,7 +1,7 @@
 mod storage;
 mod view;
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use lofigirl_shared_common::{
     api::{Action, ScrobbleRequest, SessionRequest, SessionResponse, TokenRequest, TokenResponse},
@@ -118,8 +118,8 @@ enum Msg {
     ServerHealthResponded(String),
     StartPlaying,
     UpdateTokenThenPlay(String),
-    ListenSocket(Arc<Mutex<SplitStream<WebSocket>>>),
-    NewTrackReceived(Arc<Mutex<SplitStream<WebSocket>>>, Track),
+    ListenSocket(Rc<Mutex<SplitStream<WebSocket>>>),
+    NewTrackReceived(Rc<Mutex<SplitStream<WebSocket>>>, Track),
     PongReceived,
 }
 
@@ -233,7 +233,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
                     }
                 });
                 model.tx_handle = Some(tx_handle);
-                orders.send_msg(Msg::ListenSocket(Arc::new(Mutex::new(rx))));
+                orders.send_msg(Msg::ListenSocket(Rc::new(Mutex::new(rx))));
             }
         }
         Msg::ListenSocket(rx) => {


### PR DESCRIPTION
- concurrency improvements on multi clients
- rm videoconfig
- android gradle zulu 11 > 21
- instead of full url keep youtube id as the main comparison in multi clients


Closes #397 