### PR TITLE
fix: opencv cross compilation issue with opencv-rs 0.94.2

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -11,6 +11,7 @@ RUN apt install -y build-essential curl libssl-dev clang libclang-dev pkg-config
                    crossbuild-essential-arm64 libopencv-dev:arm64 libssl-dev:arm64 libleptonica-dev:arm64 libtesseract-dev:arm64
 ENV PKG_CONFIG_PATH /usr/lib/aarch64-linux-gnu/pkgconfig/
 ENV PKG_CONFIG_ALLOW_CROSS 1
+ENV DEB_TARGET_MULTIARCH aarch64-linux-gnu
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -11,6 +11,7 @@ RUN apt install -y build-essential curl libssl-dev clang libclang-dev pkg-config
                    crossbuild-essential-armhf libopencv-dev:armhf libssl-dev:armhf libleptonica-dev:armhf libtesseract-dev:armhf
 ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
 ENV PKG_CONFIG_ALLOW_CROSS 1
+ENV DEB_TARGET_MULTIARCH arm-linux-gnueabihf
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
This [commit](https://github.com/twistedfall/opencv-rust/commit/d4c3879b04dfdf8489ef2c87f7908b6a74d28782#diff-a2e205975ab161038b6fddcdabe2d9d5d35c59c1142981af20e9917bba5f1050) makes opencv look for `dpkg-architecture --query DEB_TARGET_MULTIARCH" and fail cross-compilation. Setting "DEB_TARGET_MULTIARCH" env fixes the pkg-config to find foreign arch opencv installation.